### PR TITLE
Change label and description for Psalm Local Immutable rule

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -37,7 +37,7 @@
                      language="PHP"
                      implementationClass="de.espend.idea.php.generics.inspection.ClassStringLocalInspection"/>
 
-    <localInspection groupPath="Generics" shortName="PsalmLocalImmutableInspection" displayName="Route missing"
+    <localInspection groupPath="Generics" shortName="PsalmLocalImmutableInspection" displayName="Psalm Local Immutable"
                      groupName="Class"
                      enabledByDefault="true" level="WARNING"
                      language="PHP"

--- a/src/main/resources/inspectionDescriptions/PsalmLocalImmutableInspection.html
+++ b/src/main/resources/inspectionDescriptions/PsalmLocalImmutableInspection.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<p>Check property assign "$this->a = 'test'" of a readonly property</p>
+</body>
+</html>


### PR DESCRIPTION
I noticed this inspection has the wrong label and no description.

I created these from the inspection code and phpdoc of the inspection class.