### PR TITLE
Move Generics inspections group under PHP

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -33,13 +33,13 @@
     <fileBasedIndex implementation="de.espend.idea.php.generics.indexer.TemplateAnnotationIndex"/>
 
 
-    <localInspection groupPath="Generics" shortName="ClassStringLocalInspection" displayName="Class-string expected"
+    <localInspection groupPath="PHP,Generics" shortName="ClassStringLocalInspection" displayName="Class-string expected"
                      groupName="Class"
                      enabledByDefault="true" level="WARNING"
                      language="PHP"
                      implementationClass="de.espend.idea.php.generics.inspection.ClassStringLocalInspection"/>
 
-    <localInspection groupPath="Generics" shortName="PsalmLocalImmutableInspection" displayName="Psalm Local Immutable"
+    <localInspection groupPath="PHP,Generics" shortName="PsalmLocalImmutableInspection" displayName="Psalm Local Immutable"
                      groupName="Class"
                      enabledByDefault="true" level="WARNING"
                      language="PHP"


### PR DESCRIPTION
I think the Generics group should be under PHP rather than in the root

![image](https://user-images.githubusercontent.com/327717/80910923-23b2f280-8d33-11ea-8b3e-5f928d0d531f.png)
