### PR TITLE
Fix impossible split in TemplateAnnotationTypeProvider::complete()

### DIFF
--- a/src/main/java/de/espend/idea/php/generics/type/TemplateAnnotationTypeProvider.java
+++ b/src/main/java/de/espend/idea/php/generics/type/TemplateAnnotationTypeProvider.java
@@ -184,10 +184,16 @@ public class TemplateAnnotationTypeProvider implements PhpTypeProvider4 {
                 continue;
             }
 
-            String s1 = parameters.get(parameterIndex);
-            if (s1 != null) {
-                types.add("#" + this.getKey() + s1);
+            if (parameters.isEmpty()) {
+                return;
             }
+
+            String s1 = parameters.get(parameterIndex);
+            if (s1 == null) {
+                return;
+            }
+
+            types.add("#" + this.getKey() + s1);
         }
     }
 

--- a/src/main/java/de/espend/idea/php/generics/type/TemplateAnnotationTypeProvider.java
+++ b/src/main/java/de/espend/idea/php/generics/type/TemplateAnnotationTypeProvider.java
@@ -77,6 +77,10 @@ public class TemplateAnnotationTypeProvider implements PhpTypeProvider4 {
 
         String[] subjectAndParameters = s.substring(2).split(String.valueOf('\u0198'));
 
+        if (subjectAndParameters.length == 0) {
+            return null;
+        }
+
         // "@template for parameters"
         // split for "subject" and its "parameters"
         // PhpStorm split on multiple types too


### PR DESCRIPTION
For `s = "#ƗƘ"` the `s.substring(2).split(String.valueOf('\u0198'))` returns empty array.

This might Resolve #33. After this change I no longer see errors mentioned there.