### PR TITLE
Force use of Java 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,11 @@ intellij {
     ]
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
 patchPluginXml {
     sinceBuild '201.6668'
     changeNotes = htmlFixer('src/main/resources/META-INF/change-notes.html')


### PR DESCRIPTION
I managed to first compile with J13. 

This handles it universally so Gradle always compiles for API v11.