### PR TITLE
Update plugin URL to GitHub page

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -2,7 +2,7 @@
   <id>de.espend.idea.php.generics</id>
   <name>PHPStan / Psalm / Generics</name>
   <version>0.7.0</version>
-  <vendor email="daniel@espendiller.net" url="http://www.espend.de">espend_de</vendor>
+  <vendor email="daniel@espendiller.net" url="https://github.com/Haehnchen/idea-php-generics-plugin">espend_de</vendor>
 
   <description><![CDATA[
     <p>Provide additional support for PHPStan, Psalm and Generics related PHP features</p>


### PR DESCRIPTION
Because espend.de doesn't work at this moment.